### PR TITLE
feat: Implement GitHub Issues Reship Pipeline

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -7,6 +7,10 @@ on:
   workflow_dispatch:
     # Allows manual triggering from the GitHub Actions UI
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   generate-report:
     runs-on: ubuntu-latest
@@ -27,6 +31,16 @@ jobs:
         pip install requests openpyxl pytz python-dotenv
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
+    - name: Fetch Reship Orders
+      id: fetch_reships
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Use gh CLI to grab all open issue titles labeled "reship"
+        RESHIP_LIST=$(gh issue list --label "reship" --state "open" --json title --jq '.[].title' | paste -sd "," -)
+        echo "Found reship orders: $RESHIP_LIST"
+        echo "RESHIP_ORDERS=$RESHIP_LIST" >> $GITHUB_ENV
+
     - name: Run Report Generator Script
       id: run_script
       env:
@@ -39,6 +53,21 @@ jobs:
       run: |
         # Redirect stderr to a file so we can capture exactly why it failed
         python scripts/generate_report.py 2> error_log.txt || (cat error_log.txt; exit 1)
+
+    - name: Close Reship Issues
+      if: success()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Mark reship queue as done if the Python script succeeded
+        if [ -n "${{ env.RESHIP_ORDERS }}" ]; then
+          for id in $(gh issue list --label "reship" --state "open" --json number --jq '.[].number'); do
+            echo "Closing issue #$id"
+            gh issue close $id --reason "completed" -c "Order was successfully added to today's fulfillment report."
+          done
+        else
+          echo "No reships to close."
+        fi
 
     - name: Create Issue on Failure
       if: failure()

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -75,15 +75,19 @@ def get_report_window() -> tuple[datetime, datetime]:
 # ─── Data fetching ────────────────────────────────────────────────────────────
 
 
-def fetch_orders(start: datetime, end: datetime) -> list:
+def fetch_orders(start: datetime, end: datetime, reship_orders: list = None) -> list:
     """
-    POST to Make.com webhook with the date window.
+    POST to Make.com webhook with the date window and optional reship orders.
     Make.com should use these params to filter Shopify orders at source.
     Returns list of Shopify order objects.
     """
+    if reship_orders is None:
+        reship_orders = []
+
     payload = {
         "start": start.isoformat(),
         "end": end.isoformat(),
+        "reship_orders": reship_orders
     }
     resp = requests.post(
         WEBHOOK_URL,
@@ -337,8 +341,14 @@ def main() -> None:
             label = "Last Order"
         else:
             start, end = get_report_window()
+            reship_str = os.environ.get("RESHIP_ORDERS", "").strip()
+            reships = [r.strip() for r in reship_str.split(",")] if reship_str else []
+            
             print(f"Report window: {start.isoformat()} -> {end.isoformat()}")
-            orders = filter_orders(fetch_orders(start, end), start, end)
+            if reships:
+                print(f"Injecting Reship Orders: {reships}")
+                
+            orders = filter_orders(fetch_orders(start, end, reship_orders=reships), start, end)
             label = f"Daily Report — {end.strftime('%d %b %Y')}"
 
         tz = pytz.timezone(TIMEZONE)


### PR DESCRIPTION
Uses GitHub Actions to fetch open issues labeled `reship`, passes their IDs to the Python script via the `RESHIP_ORDERS` environment variable, and automatically closes the issues upon successful report generation. No new Python dependencies added.