### PR TITLE
Add retractable leash length SKUs

### DIFF
--- a/scripts/sku_config.py
+++ b/scripts/sku_config.py
@@ -41,7 +41,6 @@ SKU_MAP: dict[str, list[str]] = {
     "sipcup-pink":       ["Food and Water Dispensor-Pink"],
 
     # ── Retractable leash ────────────────────────────────────────────────────
-    "retractableleash":       ["Retractable Leash"],
     "retractableleash-10ft":  ["Retractable Leash-10ft"],
     "retractableleash-16ft":  ["Retractable Leash-16ft"],
 

--- a/scripts/sku_config.py
+++ b/scripts/sku_config.py
@@ -41,7 +41,9 @@ SKU_MAP: dict[str, list[str]] = {
     "sipcup-pink":       ["Food and Water Dispensor-Pink"],
 
     # ── Retractable leash ────────────────────────────────────────────────────
-    "retractableleash":  ["Retractable Leash"],
+    "retractableleash":       ["Retractable Leash"],
+    "retractableleash-10ft":  ["Retractable Leash-10ft"],
+    "retractableleash-16ft":  ["Retractable Leash-16ft"],
 
     # ── Trackers ─────────────────────────────────────────────────────────────
     "generic-tracker-apple":   ["Tracker-Apple"],

--- a/tests/test_sku.py
+++ b/tests/test_sku.py
@@ -179,22 +179,22 @@ def test_single_sipcup_order():
 def test_harness_and_retractable_leash():
     assert build_lineitem_name(order([
         ("harness-black-xs", 1),
-        ("retractableleash", 1),
-    ])) == "1x Harness-Black/XS, 1x Leash-Black, 1x Retractable Leash"
+        ("retractableleash-10ft", 1),
+    ])) == "1x Harness-Black/XS, 1x Leash-Black, 1x Retractable Leash-10ft"
 
 
 def test_multiple_quantities():
     assert build_lineitem_name(order([
         ("harness-black-xs", 2),
-        ("retractableleash", 1),
-    ])) == "2x Harness-Black/XS, 2x Leash-Black, 1x Retractable Leash"
+        ("retractableleash-16ft", 1),
+    ])) == "2x Harness-Black/XS, 2x Leash-Black, 1x Retractable Leash-16ft"
 
 def test_multiple_quantities_collation():
     assert build_lineitem_name(order([
         ("harness-black-xs", 1),
         ("harness-black-m", 1),
-        ("retractableleash", 1),
-    ])) == "1x Harness-Black/XS, 1x Harness-Black/M, 2x Leash-Black, 1x Retractable Leash"
+        ("retractableleash-10ft", 1),
+    ])) == "1x Harness-Black/XS, 1x Harness-Black/M, 2x Leash-Black, 1x Retractable Leash-10ft"
 
 
 def test_harness_and_retractable_leash_10ft():

--- a/tests/test_sku.py
+++ b/tests/test_sku.py
@@ -75,6 +75,14 @@ def test_retractable_leash():
     assert expand_sku("retractableleash", 1) == ["1x Retractable Leash"]
 
 
+def test_retractable_leash_10ft():
+    assert expand_sku("retractableleash-10ft", 1) == ["1x Retractable Leash-10ft"]
+
+
+def test_retractable_leash_16ft():
+    assert expand_sku("retractableleash-16ft", 1) == ["1x Retractable Leash-16ft"]
+
+
 # ─── expand_sku: trackers ─────────────────────────────────────────────────────
 
 
@@ -191,6 +199,20 @@ def test_multiple_quantities_collation():
         ("harness-black-m", 1),
         ("retractableleash", 1),
     ])) == "1x Harness-Black/XS, 1x Harness-Black/M, 2x Leash-Black, 1x Retractable Leash"
+
+
+def test_harness_and_retractable_leash_10ft():
+    assert build_lineitem_name(order([
+        ("harness-black-xs", 1),
+        ("retractableleash-10ft", 1),
+    ])) == "1x Harness-Black/XS, 1x Leash-Black, 1x Retractable Leash-10ft"
+
+
+def test_harness_and_retractable_leash_16ft():
+    assert build_lineitem_name(order([
+        ("harness-black-xs", 1),
+        ("retractableleash-16ft", 1),
+    ])) == "1x Harness-Black/XS, 1x Leash-Black, 1x Retractable Leash-16ft"
 
 
 # ─── build_lineitem_name: skip SKUs are excluded ─────────────────────────────

--- a/tests/test_sku.py
+++ b/tests/test_sku.py
@@ -71,10 +71,6 @@ def test_sipcup_qty_applied():
 # ─── expand_sku: retractable leash ───────────────────────────────────────────
 
 
-def test_retractable_leash():
-    assert expand_sku("retractableleash", 1) == ["1x Retractable Leash"]
-
-
 def test_retractable_leash_10ft():
     assert expand_sku("retractableleash-10ft", 1) == ["1x Retractable Leash-10ft"]
 


### PR DESCRIPTION
## Summary
- add  SKU mapping
- add  SKU mapping
- add SKU tests for the new leash variations

## Notes
- local test import currently depends on , so full pytest is not cleanly isolated yet