### PR TITLE
Add reships-only report mode

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -2,7 +2,12 @@ name: Daily Shopify Orders Report
 
 on:
   workflow_dispatch:
-    # Allows manual triggering from the GitHub Actions UI
+    inputs:
+      reships_only:
+        description: "Generate Excel from open reship issues only"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -46,9 +51,14 @@ jobs:
         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         REPORT_TIMEZONE: "Asia/Singapore"
+        RESHIPS_ONLY: ${{ github.event.inputs.reships_only }}
       run: |
+        ARGS=""
+        if [ "$RESHIPS_ONLY" = "true" ]; then
+          ARGS="$ARGS --reships-only"
+        fi
         # Redirect stderr to a file so we can capture exactly why it failed
-        python scripts/generate_report.py 2> error_log.txt || (cat error_log.txt; exit 1)
+        python scripts/generate_report.py $ARGS 2> error_log.txt || (cat error_log.txt; exit 1)
 
     - name: Close Reship Issues
       if: success()

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -385,10 +385,16 @@ def find_missing_skus(orders: list) -> list[tuple[str, str]]:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--last", action="store_true", help="Fetch only the last order via the last-order webhook")
+    parser.add_argument("--reships-only", action="store_true", help="Generate an Excel from open reship issues only")
     args = parser.parse_args()
 
     try:
-        if args.last:
+        if args.reships_only:
+            orders = []
+            tz = pytz.timezone(TIMEZONE)
+            now = datetime.now(tz)
+            label = f"Reships Only — {now.strftime('%d %b %Y')}"
+        elif args.last:
             orders = fetch_last_order()
             label = "Last Order"
         else:


### PR DESCRIPTION
## Summary
- add a `reships_only` workflow input to the daily report workflow
- add a `--reships-only` flag to `generate_report.py`
- allow generating an Excel from open reship issues only

## Behavior
- skips fetching today's normal orders
- builds the Excel only from open reship issues
- still sends the generated Excel through the existing report path
